### PR TITLE
AbyssalCraft Compatibility

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,7 @@ group= "skygrid8" // http://maven.apache.org/guides/mini/guide-naming-convention
 archivesBaseName = "SkyGrid8"
 
 minecraft {
-    version = "1.9-12.16.0.1795-1.9"
+    version = "1.9-12.16.0.1851-1.9"
     mappings = "snapshot_20160312"
 }
 

--- a/src/main/java/skygrid8/PostGenerator.java
+++ b/src/main/java/skygrid8/PostGenerator.java
@@ -3,6 +3,7 @@ package skygrid8;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Random;
+
 import net.minecraft.entity.boss.EntityDragon;
 import net.minecraft.inventory.IInventory;
 import net.minecraft.tileentity.TileEntity;
@@ -17,6 +18,8 @@ import net.minecraft.world.storage.loot.LootContext;
 import net.minecraft.world.storage.loot.LootTable;
 import net.minecraft.world.storage.loot.LootTableList;
 import net.minecraftforge.fml.common.IWorldGenerator;
+import net.minecraftforge.fml.common.Loader;
+import skygrid8.compat.abyssalcraft.SGACPlugin;
 import skygrid8.core.SG_Settings;
 
 public class PostGenerator implements IWorldGenerator
@@ -70,7 +73,9 @@ public class PostGenerator implements IWorldGenerator
 						entities = SG_Settings.spawnE;
 						break;
 					default:
-						entities = SG_Settings.spawnO;
+						if(Loader.isModLoaded("abyssalcraft"))
+							entities = SGACPlugin.assignList(world.provider.getDimension());
+						else entities = SG_Settings.spawnO;
 						break;
 				}
 				

--- a/src/main/java/skygrid8/compat/abyssalcraft/SGACPlugin.java
+++ b/src/main/java/skygrid8/compat/abyssalcraft/SGACPlugin.java
@@ -1,0 +1,67 @@
+package skygrid8.compat.abyssalcraft;
+
+import java.util.ArrayList;
+
+import net.minecraft.world.DimensionType;
+import net.minecraftforge.common.DimensionManager;
+import net.minecraftforge.fml.common.Loader;
+import skygrid8.core.SG_Settings;
+import skygrid8.core.SkyGrid8;
+
+import com.shinoow.abyssalcraft.AbyssalCraft;
+import com.shinoow.abyssalcraft.api.integration.ACPlugin;
+import com.shinoow.abyssalcraft.api.integration.IACPlugin;
+import com.shinoow.abyssalcraft.common.util.ACLogger;
+
+@ACPlugin
+public class SGACPlugin implements IACPlugin {
+
+	@Override
+	public boolean canLoad() {
+
+		return Loader.isModLoaded(SkyGrid8.MODID);
+	}
+
+	@Override
+	public String getModName() {
+
+		return SkyGrid8.NAME;
+	}
+
+	@Override
+	public void preInit() {}
+
+	@Override
+	public void init() {
+
+		SkyGrid8.logger.info("Hey AbyssalCraft, I'm turning your dimensions into grids!");
+		ACLogger.info("Wait... YOU'RE DOING WHAT?!");
+
+		//Since everything related to dimensions in my mod relies on the dim IDs, I'll use the same ones here (the keepLoaded part can be hardcoded if you want that)
+		DimensionManager.unregisterDimension(AbyssalCraft.configDimId1);
+		DimensionManager.registerDimension(AbyssalCraft.configDimId1, DimensionType.register("The Abyssal Wasteland Grid", "_awgrid", AbyssalCraft.configDimId1, WorldProviderAbyssalWastelandGrid.class, AbyssalCraft.keepLoaded1));
+
+		DimensionManager.unregisterDimension(AbyssalCraft.configDimId2);
+		DimensionManager.registerDimension(AbyssalCraft.configDimId2, DimensionType.register("The Dreadlands Grid", "_dlgrid", AbyssalCraft.configDimId3, WorldProviderDreadlandsGrid.class, AbyssalCraft.keepLoaded2));
+
+		DimensionManager.unregisterDimension(AbyssalCraft.configDimId3);
+		DimensionManager.registerDimension(AbyssalCraft.configDimId3, DimensionType.register("Omothol Grid", "_omtgrid", AbyssalCraft.configDimId3, WorldProviderOmotholGrid.class, AbyssalCraft.keepLoaded3));
+
+		DimensionManager.unregisterDimension(AbyssalCraft.configDimId4);
+		DimensionManager.registerDimension(AbyssalCraft.configDimId4, DimensionType.register("The Dark Realm Grid", "_drgrid", AbyssalCraft.configDimId4, WorldProviderDarkRealmGrid.class, AbyssalCraft.keepLoaded4));
+
+		SkyGrid8.logger.info("... And they've become grids.");
+		ACLogger.info("Oh well, probably about time I change name to AbyssalGrid...");
+	}
+
+	@Override
+	public void postInit() {}
+
+	public static ArrayList<String> assignList(int dim){
+		if(dim == AbyssalCraft.configDimId1) return SG_Settings.spawnAW;
+		if(dim == AbyssalCraft.configDimId2) return SG_Settings.spawnDL;
+		if(dim == AbyssalCraft.configDimId3) return SG_Settings.spawnOMT;
+		if(dim == AbyssalCraft.configDimId4) return SG_Settings.spawnDR;
+		return SG_Settings.spawnO;
+	}
+}

--- a/src/main/java/skygrid8/compat/abyssalcraft/WorldProviderAbyssalWastelandGrid.java
+++ b/src/main/java/skygrid8/compat/abyssalcraft/WorldProviderAbyssalWastelandGrid.java
@@ -1,0 +1,103 @@
+package skygrid8.compat.abyssalcraft;
+
+import skygrid8.ChunkProviderGrid;
+import skygrid8.config.GridRegistry;
+import net.minecraft.entity.Entity;
+import net.minecraft.util.math.Vec3d;
+import net.minecraft.world.DimensionType;
+import net.minecraft.world.WorldProvider;
+import net.minecraft.world.biome.BiomeProviderSingle;
+import net.minecraft.world.chunk.Chunk;
+import net.minecraft.world.chunk.IChunkGenerator;
+import net.minecraftforge.fml.relauncher.Side;
+import net.minecraftforge.fml.relauncher.SideOnly;
+
+import com.shinoow.abyssalcraft.AbyssalCraft;
+
+public class WorldProviderAbyssalWastelandGrid extends WorldProvider {
+
+	@Override
+	public IChunkGenerator createChunkGenerator() {
+		return new ChunkProviderGrid(worldObj, worldObj.getSeed(), GridRegistry.blocksAbyssalWasteland);
+	}
+
+	@Override
+	public void registerWorldChunkManager() {
+		worldChunkMgr = new BiomeProviderSingle(AbyssalCraft.Wastelands);
+		isHellWorld= false;
+		setDimension(AbyssalCraft.configDimId1);
+		hasNoSky = true;
+	}
+
+	@Override
+	public boolean canRespawnHere() {
+		return false;
+	}
+
+	/**
+	 * Creates the light to brightness table
+	 */
+	@Override
+	protected void generateLightBrightnessTable() {
+		float f = 0.25F;
+
+		for (int i = 0; i <= 15; ++i) {
+			float f1 = 1.0F - i / 15.0F;
+			lightBrightnessTable[i] = (1.0F - f1) / (f1 * 3.0F + 1.0F) * (1.0F - f) + f;
+		}
+	}
+
+	@Override
+	public boolean canDoRainSnowIce(Chunk chunk) {
+		return false;
+	}
+
+	@Override
+	public boolean isSurfaceWorld() {
+		return false;
+	}
+
+	@Override
+	public float calculateCelestialAngle(long par1, float par3) {
+		return 0.0F;
+	}
+
+	@Override
+	@SideOnly(Side.CLIENT)
+	public float[] calcSunriseSunsetColors(float par1, float par2) {
+		return null;
+	}
+
+	@Override
+	@SideOnly(Side.CLIENT)
+	public boolean isSkyColored() {
+		return true;
+	}
+
+	@Override
+	public Vec3d getSkyColor(Entity cameraEntity, float partialTicks) {
+		return new Vec3d(0, 180, 50);
+	}
+
+	@Override
+	@SideOnly(Side.CLIENT)
+	public float getCloudHeight() {
+		return 8.0F;
+	}
+
+	@Override
+	public String getSaveFolder() {
+		return "Abyssal_Wasteland";
+	}
+
+	@Override
+	public int getAverageGroundLevel() {
+		return 50;
+	}
+
+	@Override
+	public DimensionType getDimensionType() {
+
+		return AbyssalCraft.THE_ABYSSAL_WASTELAND;
+	}
+}

--- a/src/main/java/skygrid8/compat/abyssalcraft/WorldProviderDarkRealmGrid.java
+++ b/src/main/java/skygrid8/compat/abyssalcraft/WorldProviderDarkRealmGrid.java
@@ -1,0 +1,122 @@
+package skygrid8.compat.abyssalcraft;
+
+import skygrid8.ChunkProviderGrid;
+import skygrid8.config.GridRegistry;
+import net.minecraft.entity.Entity;
+import net.minecraft.util.math.MathHelper;
+import net.minecraft.util.math.Vec3d;
+import net.minecraft.world.DimensionType;
+import net.minecraft.world.WorldProvider;
+import net.minecraft.world.biome.BiomeProviderSingle;
+import net.minecraft.world.chunk.Chunk;
+import net.minecraft.world.chunk.IChunkGenerator;
+import net.minecraftforge.fml.relauncher.Side;
+import net.minecraftforge.fml.relauncher.SideOnly;
+
+import com.shinoow.abyssalcraft.AbyssalCraft;
+
+public class WorldProviderDarkRealmGrid extends WorldProvider {
+
+	@Override
+	public IChunkGenerator createChunkGenerator() {
+		return new ChunkProviderGrid(worldObj, worldObj.getSeed(), GridRegistry.blocksDarkRealm);
+	}
+
+	@Override
+	public void registerWorldChunkManager() {
+		worldChunkMgr = new BiomeProviderSingle(AbyssalCraft.darkRealm);
+		setDimension(AbyssalCraft.configDimId4);
+		hasNoSky = true;
+	}
+
+	@Override
+	public boolean canRespawnHere() {
+		return false;
+	}
+
+	@Override
+	protected void generateLightBrightnessTable() {
+		float f = 0.10F;
+
+		for (int i = 0; i <= 15; ++i) {
+			float f1 = 1.0F - i / 15.0F;
+			lightBrightnessTable[i] = (1.0F - f1) / (f1 * 3.0F + 1.0F) * (1.0F - f) + f;
+		}
+	}
+
+	@Override
+	@SideOnly(Side.CLIENT)
+	public Vec3d getFogColor(float par1, float par2)
+	{
+		int i = 10518688;
+		float f2 = MathHelper.cos(par1 * (float)Math.PI * 2.0F) * 2.0F + 0.5F;
+
+		if (f2 < 0.0F)
+			f2 = 0.0F;
+
+		if (f2 > 1.0F)
+			f2 = 1.0F;
+
+		float f3 = (i >> 16 & 255) / 255.0F;
+		float f4 = (i >> 8 & 255) / 255.0F;
+		float f5 = (i & 255) / 255.0F;
+		f3 *= f2 * 0.0F + 0.15F;
+		f4 *= f2 * 0.0F + 0.15F;
+		f5 *= f2 * 0.0F + 0.15F;
+		return new Vec3d(f3, f4, f5);
+	}
+
+	@Override
+	public boolean canDoRainSnowIce(Chunk chunk) {
+		return false;
+	}
+
+	@Override
+	public boolean isSurfaceWorld() {
+		return false;
+	}
+
+	@Override
+	public float calculateCelestialAngle(long par1, float par3) {
+		return 0.0F;
+	}
+
+	@Override
+	@SideOnly(Side.CLIENT)
+	public float[] calcSunriseSunsetColors(float par1, float par2) {
+		return null;
+	}
+
+	@Override
+	@SideOnly(Side.CLIENT)
+	public boolean isSkyColored() {
+		return true;
+	}
+
+	@Override
+	public Vec3d getSkyColor(Entity cameraEntity, float partialTicks) {
+		return new Vec3d(0, 0, 0);
+	}
+
+	@Override
+	@SideOnly(Side.CLIENT)
+	public float getCloudHeight() {
+		return 8.0F;
+	}
+
+	@Override
+	public String getSaveFolder() {
+		return "The_Dark_Realm";
+	}
+
+	@Override
+	public int getAverageGroundLevel() {
+		return 50;
+	}
+
+	@Override
+	public DimensionType getDimensionType() {
+
+		return AbyssalCraft.THE_DARK_REALM;
+	}
+}

--- a/src/main/java/skygrid8/compat/abyssalcraft/WorldProviderDreadlandsGrid.java
+++ b/src/main/java/skygrid8/compat/abyssalcraft/WorldProviderDreadlandsGrid.java
@@ -1,0 +1,86 @@
+package skygrid8.compat.abyssalcraft;
+
+import skygrid8.ChunkProviderGrid;
+import skygrid8.config.GridRegistry;
+import net.minecraft.util.math.Vec3d;
+import net.minecraft.world.DimensionType;
+import net.minecraft.world.WorldProvider;
+import net.minecraft.world.chunk.IChunkGenerator;
+import net.minecraftforge.fml.relauncher.Side;
+import net.minecraftforge.fml.relauncher.SideOnly;
+
+import com.shinoow.abyssalcraft.AbyssalCraft;
+import com.shinoow.abyssalcraft.common.world.WorldChunkManagerDreadlands;
+
+public class WorldProviderDreadlandsGrid extends WorldProvider {
+
+	@Override
+	public void registerWorldChunkManager() {
+		worldChunkMgr = new WorldChunkManagerDreadlands(worldObj.getSeed(), worldObj.getWorldInfo().getTerrainType());
+		hasNoSky = true;
+		setDimension(AbyssalCraft.configDimId2);
+	}
+
+	@Override
+	@SideOnly(Side.CLIENT)
+	public Vec3d getFogColor(float par1, float par2) {
+		return new Vec3d(0.20000000298023224D, 0.029999999329447746D, 0.029999999329447746D);
+	}
+
+	@Override
+	protected void generateLightBrightnessTable() {
+		float f = 0.35F;
+
+		for (int i = 0; i <= 15; ++i) {
+			float f1 = 1.0F - i / 15.0F;
+			lightBrightnessTable[i] = (1.0F - f1) / (f1 * 3.0F + 1.0F) * (1.0F - f) + f;
+		}
+	}
+
+	@Override
+	public IChunkGenerator createChunkGenerator() {
+		return new ChunkProviderGrid(worldObj, worldObj.getSeed(), GridRegistry.blocksDreadlands);
+	}
+
+	@Override
+	public boolean isSurfaceWorld() {
+		return false;
+	}
+
+	@Override
+	public boolean canCoordinateBeSpawn(int par1, int par2) {
+		return false;
+	}
+
+	@Override
+	public float calculateCelestialAngle(long par1, float par3) {
+		return 0.5F;
+	}
+
+	@Override
+	public boolean canRespawnHere() {
+		return false;
+	}
+
+	@Override
+	@SideOnly(Side.CLIENT)
+	public boolean doesXZShowFog(int par1, int par2) {
+		return true;
+	}
+
+	@Override
+	public String getSaveFolder() {
+		return "The_Dreadlands";
+	}
+
+	@Override
+	public int getAverageGroundLevel() {
+		return 50;
+	}
+
+	@Override
+	public DimensionType getDimensionType() {
+
+		return AbyssalCraft.THE_DREADLANDS;
+	}
+}

--- a/src/main/java/skygrid8/compat/abyssalcraft/WorldProviderOmotholGrid.java
+++ b/src/main/java/skygrid8/compat/abyssalcraft/WorldProviderOmotholGrid.java
@@ -1,0 +1,140 @@
+package skygrid8.compat.abyssalcraft;
+
+import skygrid8.ChunkProviderGrid;
+import skygrid8.config.GridRegistry;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.MathHelper;
+import net.minecraft.util.math.Vec3d;
+import net.minecraft.world.DimensionType;
+import net.minecraft.world.WorldProvider;
+import net.minecraft.world.biome.BiomeProviderSingle;
+import net.minecraft.world.chunk.Chunk;
+import net.minecraft.world.chunk.IChunkGenerator;
+import net.minecraftforge.fml.relauncher.Side;
+import net.minecraftforge.fml.relauncher.SideOnly;
+
+import com.shinoow.abyssalcraft.AbyssalCraft;
+import com.shinoow.abyssalcraft.api.block.ACBlocks;
+
+public class WorldProviderOmotholGrid extends WorldProvider {
+
+	@Override
+	public void registerWorldChunkManager()
+	{
+		worldChunkMgr = new BiomeProviderSingle(AbyssalCraft.omothol);
+		setDimension(AbyssalCraft.configDimId3);
+		hasNoSky = true;
+	}
+
+	@Override
+	public IChunkGenerator createChunkGenerator()
+	{
+		return new ChunkProviderGrid(worldObj, worldObj.getSeed(), GridRegistry.blocksOmothol); //normally I'd use a fixed seed here
+	}
+
+	@Override
+	protected void generateLightBrightnessTable() {
+		float f = 0.25F;
+
+		for (int i = 0; i <= 15; ++i) {
+			float f1 = 1.0F - i / 15.0F;
+			lightBrightnessTable[i] = (1.0F - f1) / (f1 * 3.0F + 1.0F) * (1.0F - f) + f;
+		}
+	}
+
+	@Override
+	public float calculateCelestialAngle(long par1, float par3)
+	{
+		return 0.0F;
+	}
+
+	@Override
+	@SideOnly(Side.CLIENT)
+	public float[] calcSunriseSunsetColors(float par1, float par2)
+	{
+		return null;
+	}
+
+	@Override
+	@SideOnly(Side.CLIENT)
+	public Vec3d getFogColor(float par1, float par2)
+	{
+		int i = 10518688;
+		float f2 = MathHelper.cos(par1 * (float)Math.PI * 2.0F) * 2.0F + 0.5F;
+
+		if (f2 < 0.0F)
+			f2 = 0.0F;
+
+		if (f2 > 1.0F)
+			f2 = 1.0F;
+
+		float f3 = (i >> 16 & 255) / 255.0F;
+		float f4 = (i >> 8 & 255) / 255.0F;
+		float f5 = (i & 255) / 255.0F;
+		f3 *= f2 * 0.0F + 0.15F;
+		f4 *= f2 * 0.0F + 0.15F;
+		f5 *= f2 * 0.0F + 0.15F;
+		return new Vec3d(f3, f4, f5);
+	}
+
+	@Override
+	public boolean canDoRainSnowIce(Chunk chunk) {
+		return false;
+	}
+
+	@Override
+	@SideOnly(Side.CLIENT)
+	public boolean isSkyColored()
+	{
+		return false;
+	}
+
+	@Override
+	public boolean canRespawnHere()
+	{
+		return false;
+	}
+
+	@Override
+	public boolean isSurfaceWorld()
+	{
+		return false;
+	}
+
+	@Override
+	@SideOnly(Side.CLIENT)
+	public float getCloudHeight()
+	{
+		return 8.0F;
+	}
+
+	@Override
+	public boolean canCoordinateBeSpawn(int x, int z)
+	{
+		return worldObj.getGroundAboveSeaLevel(new BlockPos(x, 0, z)) == ACBlocks.omothol_stone.getDefaultState();
+	}
+
+	@Override
+	public String getSaveFolder() {
+		return "Omothol";
+	}
+
+	@Override
+	public int getAverageGroundLevel()
+	{
+		return 50;
+	}
+
+	@Override
+	@SideOnly(Side.CLIENT)
+	public boolean doesXZShowFog(int par1, int par2)
+	{
+		return true;
+	}
+
+	@Override
+	public DimensionType getDimensionType() {
+
+		return AbyssalCraft.OMOTHOL;
+	}
+}

--- a/src/main/java/skygrid8/config/GridRegistry.java
+++ b/src/main/java/skygrid8/config/GridRegistry.java
@@ -12,6 +12,7 @@ import net.minecraft.block.BlockReed;
 import net.minecraft.block.BlockStem;
 import net.minecraft.init.Blocks;
 import net.minecraftforge.common.IPlantable;
+import net.minecraftforge.fml.common.Loader;
 import org.apache.logging.log4j.Level;
 import skygrid8.JsonHelper;
 import skygrid8.core.SkyGrid8;
@@ -24,6 +25,10 @@ public class GridRegistry
 	public static ArrayList<GridBlock> blocksOverworld = new ArrayList<GridBlock>();
 	public static ArrayList<GridBlock> blocksNether = new ArrayList<GridBlock>();
 	public static ArrayList<GridBlock> blocksEnd = new ArrayList<GridBlock>();
+	public static ArrayList<GridBlock> blocksAbyssalWasteland = new ArrayList<GridBlock>();
+	public static ArrayList<GridBlock> blocksDreadlands = new ArrayList<GridBlock>();
+	public static ArrayList<GridBlock> blocksOmothol = new ArrayList<GridBlock>();
+	public static ArrayList<GridBlock> blocksDarkRealm = new ArrayList<GridBlock>();
 	
 	public static GridBlock getRandom(Random rand, ArrayList<GridBlock> list)
 	{
@@ -121,6 +126,96 @@ public class GridRegistry
 		}
 		
 		SkyGrid8.logger.log(Level.INFO, "Loaded " + blocksEnd.size() + " End grid blocks");
+
+		if(Loader.isModLoaded("abyssalcraft")){
+			f = new File("config/skygrid8_abyssal_wasteland.json");
+			blocksAbyssalWasteland = new ArrayList<GridBlock>();
+			
+			if(!f.exists())
+			{
+				generateDefaults(f, blocksAbyssalWasteland);
+			} else
+			{
+				JsonArray list = JsonHelper.ReadArrayFromFile(f);
+				for(JsonElement e : list)
+				{
+					if(e == null || !e.isJsonObject())
+					{
+						continue;
+					}
+					
+					blocksAbyssalWasteland.add(new GridBlock(e.getAsJsonObject()));
+				}
+			}
+			
+			SkyGrid8.logger.log(Level.INFO, "Loaded " + blocksAbyssalWasteland.size() + " Abyssal Wasteland grid blocks");
+			
+			f = new File("config/skygrid8_dreadlands.json");
+			blocksDreadlands = new ArrayList<GridBlock>();
+			
+			if(!f.exists())
+			{
+				generateDefaults(f, blocksDreadlands);
+			} else
+			{
+				JsonArray list = JsonHelper.ReadArrayFromFile(f);
+				for(JsonElement e : list)
+				{
+					if(e == null || !e.isJsonObject())
+					{
+						continue;
+					}
+					
+					blocksDreadlands.add(new GridBlock(e.getAsJsonObject()));
+				}
+			}
+			
+			SkyGrid8.logger.log(Level.INFO, "Loaded " + blocksDreadlands.size() + " Dreadlands grid blocks");
+			
+			f = new File("config/skygrid8_omothol.json");
+			blocksOmothol = new ArrayList<GridBlock>();
+			
+			if(!f.exists())
+			{
+				generateDefaults(f, blocksOmothol);
+			} else
+			{
+				JsonArray list = JsonHelper.ReadArrayFromFile(f);
+				for(JsonElement e : list)
+				{
+					if(e == null || !e.isJsonObject())
+					{
+						continue;
+					}
+					
+					blocksOmothol.add(new GridBlock(e.getAsJsonObject()));
+				}
+			}
+			
+			SkyGrid8.logger.log(Level.INFO, "Loaded " + blocksOmothol.size() + " Omothol grid blocks");
+			
+			f = new File("config/skygrid8_dark_realm.json");
+			blocksDarkRealm = new ArrayList<GridBlock>();
+			
+			if(!f.exists())
+			{
+				generateDefaults(f, blocksDarkRealm);
+			} else
+			{
+				JsonArray list = JsonHelper.ReadArrayFromFile(f);
+				for(JsonElement e : list)
+				{
+					if(e == null || !e.isJsonObject())
+					{
+						continue;
+					}
+					
+					blocksDarkRealm.add(new GridBlock(e.getAsJsonObject()));
+				}
+			}
+			
+			SkyGrid8.logger.log(Level.INFO, "Loaded " + blocksDarkRealm.size() + " Dark Realm grid blocks");
+		}
 	}
 	
 	public static void saveBlocks()
@@ -151,6 +246,44 @@ public class GridRegistry
 			eList.add(j);
 		}
 		JsonHelper.WriteToFile(new File("config/skygrid8_end.json"), eList);
+
+		if(Loader.isModLoaded("abyssalcraft")){
+			JsonArray awList = new JsonArray();
+			for(GridBlock g : blocksAbyssalWasteland)
+			{
+				JsonObject j = new JsonObject();
+				g.writeToJson(j);
+				awList.add(j);
+			}
+			JsonHelper.WriteToFile(new File("config/skygrid8_abyssal_wasteland.json"), awList);
+
+			JsonArray dlList = new JsonArray();
+			for(GridBlock g : blocksDreadlands)
+			{
+				JsonObject j = new JsonObject();
+				g.writeToJson(j);
+				dlList.add(j);
+			}
+			JsonHelper.WriteToFile(new File("config/skygrid8_dreadlands.json"), dlList);
+
+			JsonArray omtList = new JsonArray();
+			for(GridBlock g : blocksOmothol)
+			{
+				JsonObject j = new JsonObject();
+				g.writeToJson(j);
+				omtList.add(j);
+			}
+			JsonHelper.WriteToFile(new File("config/skygrid8_omothol.json"), omtList);
+
+			JsonArray drList = new JsonArray();
+			for(GridBlock g : blocksDarkRealm)
+			{
+				JsonObject j = new JsonObject();
+				g.writeToJson(j);
+				drList.add(j);
+			}
+			JsonHelper.WriteToFile(new File("config/skygrid8_dark_realm.json"), drList);
+		}
 	}
 	
 	public static void generateDefaults(File f, ArrayList<GridBlock> blockList)

--- a/src/main/java/skygrid8/core/SG_Settings.java
+++ b/src/main/java/skygrid8/core/SG_Settings.java
@@ -14,4 +14,8 @@ public class SG_Settings
 	public static ArrayList<String> spawnO = new ArrayList<String>();
 	public static ArrayList<String> spawnN = new ArrayList<String>();
 	public static ArrayList<String> spawnE = new ArrayList<String>();
+	public static ArrayList<String> spawnAW = new ArrayList<String>();
+	public static ArrayList<String> spawnDL = new ArrayList<String>();
+	public static ArrayList<String> spawnOMT = new ArrayList<String>();
+	public static ArrayList<String> spawnDR = new ArrayList<String>();
 }

--- a/src/main/java/skygrid8/handlers/ConfigHandler.java
+++ b/src/main/java/skygrid8/handlers/ConfigHandler.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import net.minecraft.block.Block;
 import net.minecraftforge.common.config.Configuration;
+import net.minecraftforge.fml.common.Loader;
 import org.apache.logging.log4j.Level;
 import skygrid8.config.GridBlock;
 import skygrid8.config.GridRegistry;
@@ -34,6 +35,18 @@ public class ConfigHandler
 		SG_Settings.spawnN.addAll(Arrays.asList(config.getStringList("Spawners Nether", Configuration.CATEGORY_GENERAL, new String[] {"Blaze", "PigZombie", "LavaSlime"}, "Sets the possible spawner types in the grid")));
 		SG_Settings.spawnE = new ArrayList<String>();
 		SG_Settings.spawnE.addAll(Arrays.asList(config.getStringList("Spawners End", Configuration.CATEGORY_GENERAL, new String[] {"Enderman", "Endermite"}, "Sets the possible spawner types in the grid")));
+
+		if(Loader.isModLoaded("abyssalcraft")){
+			SG_Settings.spawnAW = new ArrayList<String>();
+			SG_Settings.spawnAW.addAll(Arrays.asList(config.getStringList("Spawners Abyssal Wasteland", Configuration.CATEGORY_GENERAL, new String[] {"abyssalcraft.depthsghoul", "abyssalcraft.abyssalzombie", "abyssalcraft.gskeleton", "abyssalcraft.lessershoggoth"}, "Sets ths possible spawner types in the grid")));
+			SG_Settings.spawnDL = new ArrayList<String>();
+			SG_Settings.spawnDL.addAll(Arrays.asList(config.getStringList("Spawners Dreadlands", Configuration.CATEGORY_GENERAL, new String[] {"abyssalcraft.dreadspawn", "abyssalcraft.lessershoggoth"}, "Sets ths possible spawner types in the grid")));
+			SG_Settings.spawnOMT = new ArrayList<String>();
+			SG_Settings.spawnOMT.addAll(Arrays.asList(config.getStringList("Spawners Abyssal Wasteland", Configuration.CATEGORY_GENERAL, new String[] {"abyssalcraft.remnant", "abyssalcraft.gatekeeperminion", "abyssalcraft.omotholghoul", "abyssalcraft.lessershoggoth"}, "Sets ths possible spawner types in the grid")));
+			SG_Settings.spawnDR = new ArrayList<String>();
+			SG_Settings.spawnDR.addAll(Arrays.asList(config.getStringList("Spawners Abyssal Wasteland", Configuration.CATEGORY_GENERAL, new String[] {"abyssalcraft.shadowcreature", "abyssalcraft.shadowmonster", "abyssalcraft.shadowbeast", "abyssalcraft.lessershoggoth"}, "Sets ths possible spawner types in the grid")));
+		}
+
 		GridRegistry.loadBlocks();
 		
 		if(config.getCategory(Configuration.CATEGORY_GENERAL).containsKey("Overworld Grid Blocks")) // Legacy config

--- a/src/main/java/skygrid8/handlers/EventHandler.java
+++ b/src/main/java/skygrid8/handlers/EventHandler.java
@@ -9,7 +9,7 @@ public class EventHandler
 	@SubscribeEvent
 	public void onConfigChanged(ConfigChangedEvent.OnConfigChangedEvent event)
 	{
-		if(event.modID.equals(SkyGrid8.MODID))
+		if(event.getModID().equals(SkyGrid8.MODID))
 		{
 			ConfigHandler.config.save();
 			ConfigHandler.initConfigs();


### PR DESCRIPTION
This converts all AbyssalCraft dimensions into skygrids when that mod is
present (and no code related to it is ever run if it's not present).
This should cover all of it, but you might as well take a look yourself before merging. I have added some new config options, but they won't show up unless AbyssalCraft is present (and no code from the plugin class will run unless AbyssalCraft is present as well).
I also had to update Forge (since my latest runs on a version after the one where they refactored a lot of event vars), but I've updated the part of your code that was affected.
