### PR TITLE
Dark Realm teleportation

### DIFF
--- a/src/main/java/skygrid8/compat/abyssalcraft/DarkRealmSpawnBlockHandler.java
+++ b/src/main/java/skygrid8/compat/abyssalcraft/DarkRealmSpawnBlockHandler.java
@@ -1,5 +1,7 @@
 package skygrid8.compat.abyssalcraft;
 
+import skygrid8.core.SG_Settings;
+
 import com.shinoow.abyssalcraft.AbyssalCraft;
 import com.shinoow.abyssalcraft.api.block.ACBlocks;
 
@@ -11,9 +13,11 @@ public class DarkRealmSpawnBlockHandler {
 	@SubscribeEvent
 	public void onDimensionChange(PlayerChangedDimensionEvent event){
 		if(event.toDim == AbyssalCraft.configDimId4){
-			if(!event.player.worldObj.isRemote)
+			if(!event.player.worldObj.isRemote){
+				event.player.setPositionAndUpdate(event.player.posX, SG_Settings.height - SG_Settings.dist + 1, event.player.posZ);
 				if(event.player.worldObj.isAirBlock(event.player.getPosition().down()))
 					event.player.worldObj.setBlockState(event.player.getPosition().down(), ACBlocks.darkstone.getDefaultState());
+			}
 		}
 	}
 }

--- a/src/main/java/skygrid8/compat/abyssalcraft/DarkRealmSpawnBlockHandler.java
+++ b/src/main/java/skygrid8/compat/abyssalcraft/DarkRealmSpawnBlockHandler.java
@@ -1,0 +1,19 @@
+package skygrid8.compat.abyssalcraft;
+
+import com.shinoow.abyssalcraft.AbyssalCraft;
+import com.shinoow.abyssalcraft.api.block.ACBlocks;
+
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+import net.minecraftforge.fml.common.gameevent.PlayerEvent.PlayerChangedDimensionEvent;
+
+public class DarkRealmSpawnBlockHandler {
+
+	@SubscribeEvent
+	public void onDimensionChange(PlayerChangedDimensionEvent event){
+		if(event.toDim == AbyssalCraft.configDimId4){
+			if(!event.player.worldObj.isRemote)
+				if(event.player.worldObj.isAirBlock(event.player.getPosition().down()))
+					event.player.worldObj.setBlockState(event.player.getPosition().down(), ACBlocks.darkstone.getDefaultState());
+		}
+	}
+}

--- a/src/main/java/skygrid8/compat/abyssalcraft/SGACPlugin.java
+++ b/src/main/java/skygrid8/compat/abyssalcraft/SGACPlugin.java
@@ -4,7 +4,7 @@ import java.util.ArrayList;
 
 import net.minecraft.world.DimensionType;
 import net.minecraftforge.common.DimensionManager;
-import net.minecraftforge.fml.common.Loader;
+import net.minecraftforge.common.MinecraftForge;
 import skygrid8.core.SG_Settings;
 import skygrid8.core.SkyGrid8;
 
@@ -19,7 +19,7 @@ public class SGACPlugin implements IACPlugin {
 	@Override
 	public boolean canLoad() {
 
-		return Loader.isModLoaded(SkyGrid8.MODID);
+		return true;
 	}
 
 	@Override
@@ -49,6 +49,8 @@ public class SGACPlugin implements IACPlugin {
 
 		DimensionManager.unregisterDimension(AbyssalCraft.configDimId4);
 		DimensionManager.registerDimension(AbyssalCraft.configDimId4, DimensionType.register("The Dark Realm Grid", "_drgrid", AbyssalCraft.configDimId4, WorldProviderDarkRealmGrid.class, AbyssalCraft.keepLoaded4));
+
+		MinecraftForge.EVENT_BUS.register(new DarkRealmSpawnBlockHandler());
 
 		SkyGrid8.logger.info("... And they've become grids.");
 		ACLogger.info("Oh well, probably about time I change name to AbyssalGrid...");


### PR DESCRIPTION
This PR places the player on top of the grid and places a block underneath them when entering the Dark Realm (method for entering irrelevant, as this will happen in either case to ensure that the player doesn't fall directly into the void if they travel here). The calculation done on the Y axis might need a bit of tuning (unless that setup works with the way the grid height and distance is used).
